### PR TITLE
Updates Essentials version to 1.7.2 to support custom join maps

### DIFF
--- a/epi-essentials-mobile-control/MobileControlFactory.cs
+++ b/epi-essentials-mobile-control/MobileControlFactory.cs
@@ -12,7 +12,7 @@ namespace PepperDash.Essentials
     {
         public MobileControlFactory()
         {
-            MinimumEssentialsFrameworkVersion = "1.6.9";
+            MinimumEssentialsFrameworkVersion = "1.7.2";
             TypeNames = new List<string> {"appserver", "mobilecontrol", "webserver" };
         }
 
@@ -27,7 +27,7 @@ namespace PepperDash.Essentials
     {
         public MobileControlDdvcFactory()
         {
-            MinimumEssentialsFrameworkVersion = "1.6.10";
+            MinimumEssentialsFrameworkVersion = "1.7.2";
             TypeNames = new List<string> {"mobilecontrolbridge-ddvc01", "mobilecontrolbridge-simpl"};
         }
 

--- a/packages.config
+++ b/packages.config
@@ -1,3 +1,3 @@
 <packages>
-  <package id="PepperDashEssentials" version="1.6.10-alpha-990" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
+  <package id="PepperDashEssentials" version="1.7.2" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
 </packages>


### PR DESCRIPTION
Required for the plugin to be aware of the type of the JoinMaps object on BasicConfig.  Updated minimum supported Essentials version accordingly