### PR TITLE
fix: change path for device presets model messenger

### DIFF
--- a/3-series/Messengers/DevicePresetsModelMessenger.cs
+++ b/3-series/Messengers/DevicePresetsModelMessenger.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using PepperDash.Core;
+using PepperDash.Core.Logging;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.DeviceTypeInterfaces;
 using PepperDash.Essentials.Core.Presets;
@@ -45,23 +46,32 @@ namespace PepperDash.Essentials.AppServer.Messengers
         protected override void CustomRegisterWithAppServer(MobileControlSystemController appServerController)
 #endif
         {
-            AddAction("/fullStatus", (id, content) => SendPresets());
+            AddAction("/presets/fullStatus", (id, content) => {
+                this.LogInformation("getting full status for client {id}", id);
+                try
+                {
+                    SendPresets();
+                } catch(Exception ex)
+                {
+                    Debug.LogMessage(ex, "Exception sending preset full status", this);
+                }
+            });
 
-            AddAction("/recall", (id, content) =>
+            AddAction("/presets/recall", (id, content) =>
             {
                 var p = content.ToObject<PresetChannelMessage>();
 
 
                 if (!(DeviceManager.GetDeviceForKey(p.DeviceKey) is ISetTopBoxNumericKeypad dev))
                 {
-                    Debug.Console(1, "Unable to find device with key {0}", p.DeviceKey);
+                    this.LogDebug("Unable to find device with key {0}", p.DeviceKey);
                     return;
                 }
 
                 RecallPreset(dev, p.Preset.Channel);
             });
 
-            AddAction("/save", (id, content) =>
+            AddAction("/presets/save", (id, content) =>
             {
                 var presets = content.ToObject<List<PresetChannel>>();
 

--- a/3-series/MobileControlSystemController.cs
+++ b/3-series/MobileControlSystemController.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Org.BouncyCastle.Crypto.Prng;
 using PepperDash.Core;
+using PepperDash.Core.Logging;
 using PepperDash.Essentials.AppServer;
 using PepperDash.Essentials.AppServer.Messengers;
 using PepperDash.Essentials.Core;
@@ -474,7 +475,7 @@ namespace PepperDash.Essentials
 
                             var presetsMessenger = new DevicePresetsModelMessenger(
                                 $"{device.Key}-presets-{Key}",
-                                $"/device/{device.Key}/presets",
+                                $"/device/{device.Key}",
                                 presetsDevice
                             );
 
@@ -2509,17 +2510,12 @@ Mobile Control Direct Server Infromation:
                         // /room/roomAB
 
                         // Can't do direct comparison because it will match /room/roomA with /room/roomA/xxx instead of /room/roomAB/xxx
-                        var handlersKv = _actionDictionary.FirstOrDefault(kv =>
-                            message.Type.StartsWith(kv.Key + "/") // adds trailing slash to ensure above case is handled
-                        );
+                        var handlersKv = _actionDictionary.FirstOrDefault(kv => message.Type.StartsWith(kv.Key + "/")); // adds trailing slash to ensure above case is handled
+                        
 
                         if (handlersKv.Key == null)
                         {
-                            Debug.Console(
-                                1,
-                                this,
-                                "-- Warning: Incoming message has no registered handler"
-                            );
+                            this.LogInformation("-- Warning: Incoming message has no registered handler {type}", message.Type);
                             break;
                         }
 
@@ -2540,10 +2536,9 @@ Mobile Control Direct Server Infromation:
             {
                 Debug.LogMessage(
                     err,
-                    "Unable to parse {message}:{exception}",
+                    "Unable to parse {message}",
                     this,
-                    messageText,
-                    err
+                    messageText
                 );
             }
         }


### PR DESCRIPTION
Messages with path `/device/{presetDevice}/presets/fullStatus` were getting matched with the wrong base path `/device/{presetDevice}` instead of `/device/{presetDevice}/presets`. Changing the base path for the device presets model messenger to `/device/{presetDevice}` and putting the prefix `/presets` in the messenger actions ensures that the messages reach the correct messenger.