### PR TITLE
Update messenger registration and Message handling

### DIFF
--- a/3-series/Messengers/DevicePresetsModelMessenger.cs
+++ b/3-series/Messengers/DevicePresetsModelMessenger.cs
@@ -46,7 +46,7 @@ namespace PepperDash.Essentials.AppServer.Messengers
         protected override void CustomRegisterWithAppServer(MobileControlSystemController appServerController)
 #endif
         {
-            AddAction("/presets/fullStatus", (id, content) => {
+            AddAction("/fullStatus", (id, content) => {
                 this.LogInformation("getting full status for client {id}", id);
                 try
                 {
@@ -57,7 +57,7 @@ namespace PepperDash.Essentials.AppServer.Messengers
                 }
             });
 
-            AddAction("/presets/recall", (id, content) =>
+            AddAction("/recall", (id, content) =>
             {
                 var p = content.ToObject<PresetChannelMessage>();
 
@@ -71,7 +71,7 @@ namespace PepperDash.Essentials.AppServer.Messengers
                 RecallPreset(dev, p.Preset.Channel);
             });
 
-            AddAction("/presets/save", (id, content) =>
+            AddAction("/save", (id, content) =>
             {
                 var presets = content.ToObject<List<PresetChannel>>();
 

--- a/3-series/Messengers/MessengerBase.cs
+++ b/3-series/Messengers/MessengerBase.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using PepperDash.Core;
+using PepperDash.Core.Logging;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.DeviceTypeInterfaces;
 using System;
@@ -91,10 +92,17 @@ namespace PepperDash.Essentials.AppServer.Messengers
 
         private void HandleMessage(string path, string id, JToken content)
         {
+            //this.LogVerbose("Received message with path: {path}", path);
+
+            //this.LogVerbose("Message Path: {MessagePath}", MessagePath);
+
             // replace base path with empty string. Should leave something like /fullStatus
             var route = path.Replace(MessagePath, string.Empty); 
 
-            if(!_actions.TryGetValue(route, out var action)) {                
+            //this.LogVerbose("Route: {route}", route);
+
+            if(!_actions.TryGetValue(route, out var action)) {
+                this.LogVerbose($"{route} not found in actions", route);
                 return;
             }
 

--- a/3-series/MobileControlSystemController.cs
+++ b/3-series/MobileControlSystemController.cs
@@ -1308,7 +1308,7 @@ namespace PepperDash.Essentials
         {
             if (_messengers.ContainsKey(messenger.Key))
             {
-                Debug.Console(1, this, "Messenger with key {0} already added", messenger.Key);
+                this.LogDebug("Messenger with key {messengerKey} already added", messenger.Key);
                 return;
             }
 
@@ -1322,27 +1322,27 @@ namespace PepperDash.Essentials
                 _roomBridges.Add(roomBridge);
             }
 
-            Debug.Console(
-                2,
-                this,
-                "Adding messenger with key {0} for path {1}",
+            this.LogVerbose(
+                "Adding messenger with key {messengerKey} for path {messagePath}",
                 messenger.Key,
                 messenger.MessagePath
             );
 
             _messengers.Add(messenger.Key, messenger);
 
-            messenger.RegisterWithAppServer(this);
+            if(_initialized)
+            {
+                this.LogDebug("Registering messenger {messengerKey} AFTER initialization", messenger.Key);
+                messenger.RegisterWithAppServer(this);
+            }
         }
 
         private void AddDefaultDeviceMessenger(IMobileControlMessenger messenger)
         {
             if (_defaultMessengers.ContainsKey(messenger.Key))
             {
-                Debug.Console(
-                    1,
-                    this,
-                    "Default messenger with key {0} already added",
+               this.LogDebug(
+                    "Default messenger with key {messengerKey} already added",
                     messenger.Key
                 );
                 return;
@@ -1352,10 +1352,8 @@ namespace PepperDash.Essentials
             {
                 simplMessenger.ConfigurationIsReady += Bridge_ConfigurationIsReady;
             }
-            Debug.Console(
-                2,
-                this,
-                "Adding default messenger with key {0} for path {1}",
+            this.LogVerbose(
+                "Adding default messenger with key {messengerKey} for path {messagePath}",
                 messenger.Key,
                 messenger.MessagePath
             );
@@ -1364,16 +1362,15 @@ namespace PepperDash.Essentials
 
             if (_initialized)
             {
+                this.LogDebug("Registering default messenger {messengerKey} AFTER initialization", messenger.Key);
                 RegisterMessengerWithServer(messenger);
             }
         }
 
         private void RegisterMessengerWithServer(IMobileControlMessenger messenger)
         {
-            Debug.Console(
-                2,
-                this,
-                "Registering messenger with key {0} for path {1}",
+            this.LogVerbose(
+                "Registering messenger with key {messengerKey} for path {messagePath}",
                 messenger.Key,
                 messenger.MessagePath
             );
@@ -1391,15 +1388,8 @@ namespace PepperDash.Essentials
                 }
                 catch (Exception ex)
                 {
-                    Debug.Console(
-                        0,
-                        this,
-                        $"Exception registering paths for {messenger.Key}: {ex.Message}"
-                    );
-                    Debug.Console(
-                        2,
-                        this,
-                        $"Exception registering paths for {messenger.Key}: {ex.StackTrace}"
+                    Debug.LogMessage(ex,
+                        "Exception registering paths for default messenger {messengerKey}", this, messenger.Key
                     );
                     continue;
                 }
@@ -1413,15 +1403,8 @@ namespace PepperDash.Essentials
                 }
                 catch (Exception ex)
                 {
-                    Debug.Console(
-                        0,
-                        this,
-                        $"Exception registering paths for {messenger.Key}: {ex.Message}"
-                    );
-                    Debug.Console(
-                        2,
-                        this,
-                        $"Exception registering paths for {messenger.Key}: {ex.StackTrace}"
+                    Debug.LogMessage(ex,
+                        "Exception registering paths for messenger {messengerKey}", this, messenger.Key
                     );
                     continue;
                 }

--- a/3-series/MobileControlSystemController.cs
+++ b/3-series/MobileControlSystemController.cs
@@ -1685,6 +1685,7 @@ namespace PepperDash.Essentials
                     actionList.Any(a =>
                         a.Messenger.GetType() == messenger.GetType()
                         && a.Messenger.DeviceKey == messenger.DeviceKey
+                        && a.Messenger.MessagePath == messenger.MessagePath
                     )
                 )
                 {
@@ -1693,6 +1694,7 @@ namespace PepperDash.Essentials
                         this,
                         $"Messenger of type {messenger.GetType().Name} already exists. Skipping actions for {messenger.Key}"
                     );
+
                     return;
                 }
 
@@ -2550,16 +2552,18 @@ Mobile Control Direct Server Infromation:
                         // /room/roomAB
 
                         // Can't do direct comparison because it will match /room/roomA with /room/roomA/xxx instead of /room/roomAB/xxx
-                        var handlersKv = _actionDictionary.FirstOrDefault(kv => message.Type.StartsWith(kv.Key + "/")); // adds trailing slash to ensure above case is handled
-                        
+                        // /device/aquilon-processor/fullStatus 
+                        // /device/aquilon-processor/screen-1/fullStatus
+                        // /device/aquilon-processor/screen-2/fullStatus
+                        // /device/aquilon-processor/screen-3/fullStatus
+                        //var handlersKv = _actionDictionary.FirstOrDefault(kv => message.Type.StartsWith(kv.Key + "/")); // adds trailing slash to ensure above case is handled
+                        var handlers = _actionDictionary.Where(kv => message.Type.StartsWith(kv.Key + "/")).SelectMany(kv => kv.Value).ToList();
 
-                        if (handlersKv.Key == null)
+                        if (handlers.Count == 0)
                         {
                             this.LogInformation("-- Warning: Incoming message has no registered handler {type}", message.Type);
                             break;
                         }
-
-                        var handlers = handlersKv.Value;
 
                         foreach (var handler in handlers)
                         {

--- a/4-series/epi-essentials-mobile-control/epi-essentials-mobile-control.csproj
+++ b/4-series/epi-essentials-mobile-control/epi-essentials-mobile-control.csproj
@@ -29,7 +29,9 @@
     <DefineConstants>TRACE;SERIES4</DefineConstants>
   </PropertyGroup>  
   <ItemGroup>
-    <PackageReference Include="PepperDashEssentials" Version="2.0.0-alpha-2567" />
+    <PackageReference Include="PepperDashEssentials" Version="2.0.0-alpha-2567" >
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="WebSocketSharp-netstandard" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/4-series/mobile-control-messengers/Messengers/ISelectableItemsMessenger.cs
+++ b/4-series/mobile-control-messengers/Messengers/ISelectableItemsMessenger.cs
@@ -1,34 +1,27 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using PepperDash.Core;
 using PepperDash.Essentials.Core.DeviceTypeInterfaces;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json.Converters;
 using PepperDash.Core.Logging;
 
 namespace PepperDash.Essentials.AppServer.Messengers
 {
     public class ISelectableItemsMessenger<TKey> : MessengerBase
     {
-        private static readonly JsonSerializer serializer = new JsonSerializer { Converters = { new StringEnumConverter() } };
+        
         private ISelectableItems<TKey> itemDevice;
 
-        private readonly string _propName;
         public ISelectableItemsMessenger(string key, string messagePath, ISelectableItems<TKey> device, string propName) : base(key, messagePath, device as IKeyName)
         {
-            itemDevice = device;
-            _propName = propName;
+            itemDevice = device;        
         }
 
         protected override void RegisterActions()
         {
             base.RegisterActions();
 
-            AddAction($"/{_propName}/fullStatus", (id, context) =>
+            AddAction($"/fullStatus", (id, context) =>
             {
                 SendFullStatus();
             });
@@ -48,7 +41,7 @@ namespace PepperDash.Essentials.AppServer.Messengers
                 var key = input.Key;
                 var localItem = input.Value;                
 
-                AddAction($"/{_propName}/{key}", (id, content) =>
+                AddAction($"/{key}", (id, content) =>
                 {
                     localItem.Select();
                 });

--- a/4-series/mobile-control-messengers/Messengers/ISelectableItemsMessenger.cs
+++ b/4-series/mobile-control-messengers/Messengers/ISelectableItemsMessenger.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Converters;
+using PepperDash.Core.Logging;
 
 namespace PepperDash.Essentials.AppServer.Messengers
 {
@@ -17,7 +18,7 @@ namespace PepperDash.Essentials.AppServer.Messengers
         private ISelectableItems<TKey> itemDevice;
 
         private readonly string _propName;
-        public ISelectableItemsMessenger(string key, string messagePath, ISelectableItems<TKey> device, string propName) : base(key, messagePath, device as Device)
+        public ISelectableItemsMessenger(string key, string messagePath, ISelectableItems<TKey> device, string propName) : base(key, messagePath, device as IKeyName)
         {
             itemDevice = device;
             _propName = propName;
@@ -61,10 +62,32 @@ namespace PepperDash.Essentials.AppServer.Messengers
 
         private void SendFullStatus()
         {
-            var stateObject = new JObject();
-            stateObject[_propName] = JToken.FromObject(itemDevice, serializer);
-            PostStatusMessage(stateObject);
+            try
+            { 
+                this.LogInformation("Sending full status");
+
+                var stateObject = new ISelectableItemsStateMessage<TKey>
+                {
+                    Items = itemDevice.Items,
+                    CurrentItem = itemDevice.CurrentItem
+                };
+
+                PostStatusMessage(stateObject);
+            }
+            catch (Exception e)
+            {
+                this.LogError("Error sending full status: {0}", e.Message);
+            }
         }
+    }
+
+    public class ISelectableItemsStateMessage<TKey> : DeviceStateMessageBase
+    {
+        [JsonProperty("items")]
+        public Dictionary<TKey, ISelectableItem> Items { get; set; }
+
+        [JsonProperty("currentItem")]
+        public TKey CurrentItem { get; set; }
     }
 
 }

--- a/4-series/mobile-control-messengers/Messengers/ISelectableItemsMessenger.cs
+++ b/4-series/mobile-control-messengers/Messengers/ISelectableItemsMessenger.cs
@@ -28,7 +28,7 @@ namespace PepperDash.Essentials.AppServer.Messengers
         {
             base.RegisterActions();
 
-            AddAction("/fullStatus", (id, context) =>
+            AddAction($"/{_propName}/fullStatus", (id, context) =>
             {
                 SendFullStatus();
             });
@@ -48,7 +48,7 @@ namespace PepperDash.Essentials.AppServer.Messengers
                 var key = input.Key;
                 var localItem = input.Value;                
 
-                AddAction($"/{key}", (id, content) =>
+                AddAction($"/{_propName}/{key}", (id, content) =>
                 {
                     localItem.Select();
                 });

--- a/4-series/mobile-control-messengers/mobile-control-messengers.csproj
+++ b/4-series/mobile-control-messengers/mobile-control-messengers.csproj
@@ -62,6 +62,8 @@
     <Folder Include="SIMPLJoinMaps\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="PepperDashEssentials" Version="2.0.0-alpha-2567" />
+    <PackageReference Include="PepperDashEssentials" Version="2.0.0-alpha-2567" >
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- **fix: fixes the SendFullStatus() method for ISelectableItemsMessenger**
- **fix: updates the parsing method for the message path to allow for multiple messengers of the same type for the same device but with unique message paths**
- **build: update packages to not include Essentials files**
- **feat: fix messengers registration**
